### PR TITLE
Fix test failure with 8.0.0beta4

### DIFF
--- a/src/FinfoMimeTypeDetectorTest.php
+++ b/src/FinfoMimeTypeDetectorTest.php
@@ -71,7 +71,7 @@ class FinfoMimeTypeDetectorTest extends TestCase
     {
         $mimeType = $this->detector->detectMimeTypeFromFile(__DIR__.'/../test_files/flysystem.svg');
 
-        $this->assertEquals('image/svg', $mimeType);
+        $this->assertStringStartsWith('image/svg', $mimeType);
     }
 
     /**


### PR DESCRIPTION
Missing in 485f75211335bfd69882bee7d3fccc730485aa82


```
There was 1 failure:

1) League\MimeTypeDetection\FinfoMimeTypeDetectorTest::detecting_from_a_file_location
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'image/svg'
+'image/svg+xml'

/dev/shm/BUILD/mime-type-detection-485f75211335bfd69882bee7d3fccc730485aa82/src/FinfoMimeTypeDetectorTest.php:74

FAILURES!
Tests: 14, Assertions: 22, Failures: 1.

```