### PR TITLE
Allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-fileinfo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.8",
+        "phpunit/phpunit": "^8.5.8 || ^9.3",
         "phpstan/phpstan": "^0.12.36"
     },
     "autoload": {


### PR DESCRIPTION
As this is the only version compatible with PHP 8


```
Runtime:       PHP 8.0.0beta4
Configuration: /dev/shm/BUILD/mime-type-detection-ea2fbfc988bade315acd5967e6d02274086d0f28/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

..............                                                    14 / 14 (100%)

Time: 00:00.007, Memory: 6.00 MB

OK (14 tests, 22 assertions)

```