### PR TITLE
Use less memory when detecting MIME type

### DIFF
--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -31,9 +31,7 @@ class FinfoMimeTypeDetector implements MimeTypeDetector
 
     public function detectMimeType(string $path, $contents): ?string
     {
-        $mimeType = is_string($contents)
-            ? (@$this->finfo->buffer($contents) ?: null)
-            : null;
+        $mimeType = @$this->finfo->file($path) ?: null;
 
         if ($mimeType !== null && ! in_array($mimeType, self::INCONCLUSIVE_MIME_TYPES)) {
             return $mimeType;

--- a/src/FinfoMimeTypeDetectorTest.php
+++ b/src/FinfoMimeTypeDetectorTest.php
@@ -31,19 +31,6 @@ class FinfoMimeTypeDetectorTest extends TestCase
     /**
      * @test
      */
-    public function detecting_mime_type_from_contents(): void
-    {
-        /** @var string $contents */
-        $contents = file_get_contents(__DIR__.'/../test_files/flysystem.svg');
-
-        $mimeType = $this->detector->detectMimeType('flysystem.svg', $contents);
-
-        $this->assertStringStartsWith('image/svg', $mimeType);
-    }
-
-    /**
-     * @test
-     */
     public function detecting_mime_type_from_buffer(): void
     {
         /** @var string $contents */


### PR DESCRIPTION
Bench, with the following script

```php
<?php

m();
$contents = str_repeat('x', 5_000_000);
file_put_contents('/tmp/oo', $contents);
m();
$finfo = new Finfo(FILEINFO_MIME_TYPE, '');
m();
$mimeType = $finfo->buffer($contents);
// $mimeType = $finfo->file('/tmp/oo');
m();

function m() {
    printf("%.2fMb\n", memory_get_peak_usage(true) / 1024 / 1024);
}
```

## With file
>/tmp php test.php 
2.00Mb
6.77Mb
6.77Mb
22.77Mb

## File buffer
>/tmp php test.php 
2.00Mb
6.77Mb
6.77Mb
73.53Mb
