### PR TITLE
add reverse matching of mimetype to possible extensions

### DIFF
--- a/src/GeneratedExtensionToMimeTypeMap.php
+++ b/src/GeneratedExtensionToMimeTypeMap.php
@@ -1215,4 +1215,16 @@ class GeneratedExtensionToMimeTypeMap implements ExtensionToMimeTypeMap
     {
         return self::MIME_TYPES_FOR_EXTENSIONS[$extension] ?? null;
     }
+
+    /**
+     * @param string $mimeType
+     * @return string[]
+     */
+    public function lookupExtensions(string $mimeType): array
+    {
+        return array_keys(array_filter(self::MIME_TYPES_FOR_EXTENSIONS, function ($mimeTypeFromArray) use ($mimeType
+        ): bool {
+            return $mimeType === $mimeTypeFromArray;
+        }));
+    }
 }

--- a/src/GeneratedExtensionToMimeTypeMapTest.php
+++ b/src/GeneratedExtensionToMimeTypeMapTest.php
@@ -53,8 +53,10 @@ class GeneratedExtensionToMimeTypeMapTest extends TestCase
     /**
      * @test
      * @dataProvider expectedExtensionResults
+     * @param string $mimeType
+     * @param string[] $expectedExtensions
      */
-    public function looking_up_extensions($mimeType, $expectedExtensions): void
+    public function looking_up_extensions(string $mimeType, array $expectedExtensions): void
     {
         $map = new GeneratedExtensionToMimeTypeMap();
         $actual = $map->lookupExtensions($mimeType);

--- a/src/GeneratedExtensionToMimeTypeMapTest.php
+++ b/src/GeneratedExtensionToMimeTypeMapTest.php
@@ -49,4 +49,27 @@ class GeneratedExtensionToMimeTypeMapTest extends TestCase
 
         $this->assertEquals($source, $storedSource);
     }
+
+    /**
+     * @test
+     * @dataProvider expectedExtensionResults
+     */
+    public function looking_up_extensions($mimeType, $expectedExtensions): void
+    {
+        $map = new GeneratedExtensionToMimeTypeMap();
+        $actual = $map->lookupExtensions($mimeType);
+
+        sort($expectedExtensions);
+        sort($actual);
+
+        $this->assertEquals($expectedExtensions, $actual);
+    }
+
+    public function expectedExtensionResults(): Generator
+    {
+        yield ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', ['docx']];
+        yield ['image/jpeg', ['jpg', 'jpeg', 'jpe']];
+        yield ['image/svg+xml', ['svg', 'svgz']];
+        yield ['lol/lol', []];
+    }
 }

--- a/src/Generation/ExtensionToMimeTypeMap.php.template
+++ b/src/Generation/ExtensionToMimeTypeMap.php.template
@@ -17,4 +17,16 @@ class ExtensionToMimeTypeMapClass implements ExtensionToMimeTypeMap
     {
         return self::MIME_TYPES_FOR_EXTENSIONS[$extension] ?? null;
     }
+
+    /**
+     * @param string $mimeType
+     * @return string[]
+     */
+    public function lookupExtensions(string $mimeType): array
+    {
+        return array_keys(array_filter(self::MIME_TYPES_FOR_EXTENSIONS, function ($mimeTypeFromArray) use ($mimeType
+        ): bool {
+            return $mimeType === $mimeTypeFromArray;
+        }));
+    }
 }


### PR DESCRIPTION
Sometimes it's necessary to get possible extensions from a given mime-type.

This pr provides a reverse lookup from the `GeneratedExtensionToMimeTypeMap`.