### PR TITLE
Inherit PHPUnit's TestCase instead of PHPStan's

### DIFF
--- a/src/OverridingExtensionToMimeTypeMapTest.php
+++ b/src/OverridingExtensionToMimeTypeMapTest.php
@@ -2,7 +2,7 @@
 
 namespace League\MimeTypeDetection;
 
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class OverridingExtensionToMimeTypeMapTest extends TestCase
 {


### PR DESCRIPTION
One of the test classes inherits PHPStan's UnitTest class instead of
the usual PHPUnit TestCase. It seems to give identical behavior in this
test, and sticking to the typical PHPUnit class is more consistent.