### PR TITLE
Add file extensions "dts", "pv" and "pxf"

### DIFF
--- a/src/Generation/FlysystemProvidedMimeTypeProvider.php
+++ b/src/Generation/FlysystemProvidedMimeTypeProvider.php
@@ -185,7 +185,7 @@ class FlysystemProvidedMimeTypeProvider implements MimeTypeProvider
             new MimeTypeForExtension('application/vnd.oasis.opendocument.text-template', 'ott'),
             new MimeTypeForExtension('application/STEP', 'step'),
             new MimeTypeForExtension('application/STEP', 'stp'),
-            new MimeTypeForExtension('application/tajima', 'dst'),
+            new MimeTypeForExtension('application/octet-stream', 'dst'),
             new MimeTypeForExtension('application/octet-stream', 'pv'),
             new MimeTypeForExtension('application/octet-stream', 'pxf'),
         ];

--- a/src/Generation/FlysystemProvidedMimeTypeProvider.php
+++ b/src/Generation/FlysystemProvidedMimeTypeProvider.php
@@ -185,6 +185,9 @@ class FlysystemProvidedMimeTypeProvider implements MimeTypeProvider
             new MimeTypeForExtension('application/vnd.oasis.opendocument.text-template', 'ott'),
             new MimeTypeForExtension('application/STEP', 'step'),
             new MimeTypeForExtension('application/STEP', 'stp'),
+            new MimeTypeForExtension('application/octet-stream', 'dst'),
+            new MimeTypeForExtension('application/octet-stream', 'pv'),
+            new MimeTypeForExtension('application/octet-stream', 'pxf'),
         ];
     }
 }

--- a/src/Generation/FlysystemProvidedMimeTypeProvider.php
+++ b/src/Generation/FlysystemProvidedMimeTypeProvider.php
@@ -185,7 +185,7 @@ class FlysystemProvidedMimeTypeProvider implements MimeTypeProvider
             new MimeTypeForExtension('application/vnd.oasis.opendocument.text-template', 'ott'),
             new MimeTypeForExtension('application/STEP', 'step'),
             new MimeTypeForExtension('application/STEP', 'stp'),
-            new MimeTypeForExtension('application/octet-stream', 'dst'),
+            new MimeTypeForExtension('application/tajima', 'dst'),
             new MimeTypeForExtension('application/octet-stream', 'pv'),
             new MimeTypeForExtension('application/octet-stream', 'pxf'),
         ];


### PR DESCRIPTION
Hello Frank de Jong,

I would like to ask you to include these 3 file extensions in your project. These are files for printing / embroidery machines.

I found this PR: https://github.com/thephpleague/mime-type-detection/pull/18#issuecomment-1261220090 and implemented my change as the solution you suggested from this PR.

Thank you very much for your help.