### PR TITLE
Fix to error: "update to newer phpstan is blocked"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0",
-        "phpstan/phpstan": "^0.12.68",
+        "phpstan/phpstan": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
The app I am working on uses your lib. My app also uses phpstan. I cannot update phpstan to newer version - like ^1.0, because this lib requires "phpstan/phpstan": "^0.12.68" and it got conflicts the update. This PR is to fix it.

Below is the example output of bug:
![image](https://github.com/thephpleague/mime-type-detection/assets/20913995/0f916d92-43d8-460c-98c3-40b92931cb06)
And here https://github.com/thephpleague/mime-type-detection/blob/main/composer.json#L21 and here https://packagist.org/packages/league/mime-type-detection we can see the dependency to phpstan is blocked to the very old version.
While there are phpstan versions +1.0.0 having new features and support to newer php features and bugs fixed (https://packagist.org/packages/phpstan/phpstan).

Please update this dependency to phpstan to version ^1.0.0 (or sth similar >= than 1.0.0)