### PR TITLE
Add support for stream resources in FinfoMimeTypeDetector::detectMimeType()

### DIFF
--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -53,9 +53,12 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
 
     public function detectMimeType(string $path, $contents): ?string
     {
-        $mimeType = is_string($contents)
-            ? (@$this->finfo->buffer($this->takeSample($contents)) ?: null)
-            : null;
+        $mimeType = null;
+        if (is_string($contents)) {
+            $mimeType = @$this->finfo->buffer($this->takeSample($contents));
+        } elseif (is_resource($contents) && get_resource_type($contents) === 'stream') {
+            $mimeType = @$this->finfo->buffer(stream_get_contents($contents, $this->bufferSampleSize, 0));
+        }
 
         if ($mimeType !== null && ! in_array($mimeType, $this->inconclusiveMimetypes)) {
             return $mimeType;

--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -57,7 +57,9 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
         if (is_string($contents)) {
             $mimeType = @$this->finfo->buffer($this->takeSample($contents));
         } elseif (is_resource($contents) && get_resource_type($contents) === 'stream') {
+            $streamPosition = ftell($contents);
             $mimeType = @$this->finfo->buffer(stream_get_contents($contents, $this->bufferSampleSize, 0));
+            fseek($contents, $streamPosition);
         }
 
         if ($mimeType !== null && ! in_array($mimeType, $this->inconclusiveMimetypes)) {

--- a/src/FinfoMimeTypeDetectorTest.php
+++ b/src/FinfoMimeTypeDetectorTest.php
@@ -125,4 +125,18 @@ class FinfoMimeTypeDetectorTest extends TestCase
 
         $this->assertEquals('image/svg+xml', $mimeType);
     }
+
+    /**
+     * @test
+     */
+    public function detecting_keeps_stream_contents_positions_unchanged(): void
+    {
+        /** @var resource $handle */
+        $handle = fopen(__DIR__ . '/../test_files/flysystem.svg', 'r+');
+        fseek($handle, 10);
+        $mimeType = $this->detector->detectMimeType('flysystem.unknown', $handle);
+        $this->assertEquals('image/svg+xml', $mimeType);
+        $this->assertEquals(10, ftell($handle));
+        fclose($handle);
+    }
 }

--- a/src/FinfoMimeTypeDetectorTest.php
+++ b/src/FinfoMimeTypeDetectorTest.php
@@ -101,13 +101,27 @@ class FinfoMimeTypeDetectorTest extends TestCase
     /**
      * @test
      */
-    public function detecting_uses_extensions_when_a_resource_is_presented(): void
+    public function detecting_uses_extensions_when_a_invalid_resource_is_presented(): void
     {
         /** @var resource $handle */
         $handle = fopen(__DIR__ . '/../test_files/flysystem.svg', 'r+');
         fclose($handle);
 
         $mimeType = $this->detector->detectMimeType('flysystem.svg', $handle);
+
+        $this->assertEquals('image/svg+xml', $mimeType);
+    }
+
+    /**
+     * @test
+     */
+    public function detecting_uses_stream_contents_when_a_valid_resource_is_presented(): void
+    {
+        /** @var resource $handle */
+        $handle = fopen(__DIR__ . '/../test_files/flysystem.svg', 'r+');
+
+        $mimeType = $this->detector->detectMimeType('flysystem.unknown', $handle);
+        fclose($handle);
 
         $this->assertEquals('image/svg+xml', $mimeType);
     }


### PR DESCRIPTION
As far as I can tell it is valid to call that method with a resource. As such I think it's worth to attempt to detect the mime-type by the stream contents too.
This should be viable via stream_get_contents() while maintaining the stream pointers using ftell() and fseek().