### PR TITLE
Add PHP 8.4 compatibility

### DIFF
--- a/src/ExtensionMimeTypeDetector.php
+++ b/src/ExtensionMimeTypeDetector.php
@@ -13,7 +13,7 @@ class ExtensionMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
      */
     private $extensions;
 
-    public function __construct(ExtensionToMimeTypeMap $extensions = null)
+    public function __construct(?ExtensionToMimeTypeMap $extensions = null)
     {
         $this->extensions = $extensions ?: new GeneratedExtensionToMimeTypeMap();
     }

--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -41,7 +41,7 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
 
     public function __construct(
         string $magicFile = '',
-        ExtensionToMimeTypeMap $extensionMap = null,
+        ?ExtensionToMimeTypeMap $extensionMap = null,
         ?int $bufferSampleSize = null,
         array $inconclusiveMimetypes = self::INCONCLUSIVE_MIME_TYPES
     ) {


### PR DESCRIPTION
Fixes two issues:

```
League\MimeTypeDetection\FinfoMimeTypeDetector::__construct(): Implicitly marking parameter $extensionMap as nullable is deprecated, the explicit nullable type must be used instead
League\MimeTypeDetection\ExtensionMimeTypeDetector::__construct(): Implicitly marking parameter $extensions as nullable is deprecated, the explicit nullable type must be used instead
```

See https://wiki.php.net/rfc/deprecate-implicitly-nullable-types