### PR TITLE
Fix mime type mapping for aac extension

### DIFF
--- a/src/GeneratedExtensionToMimeTypeMap.php
+++ b/src/GeneratedExtensionToMimeTypeMap.php
@@ -2282,7 +2282,7 @@ class GeneratedExtensionToMimeTypeMap implements ExtensionToMimeTypeMap, Extensi
         'application/gpg-keys' => ['gpg'],
         'application/x-pkcs7' => ['rsa'],
         'video/3gp' => ['3gp'],
-        'audio/acc' => ['aac'],
+        'audio/aac' => ['aac'],
         'application/vnd.mpegurl' => ['m4u'],
         'application/videolan' => ['vlc'],
         'audio/x-au' => ['au'],

--- a/src/GeneratedExtensionToMimeTypeMap.php
+++ b/src/GeneratedExtensionToMimeTypeMap.php
@@ -23,7 +23,7 @@ class GeneratedExtensionToMimeTypeMap implements ExtensionToMimeTypeMap, Extensi
         '7zip' => 'application/x-7z-compressed',
         '123' => 'application/vnd.lotus-1-2-3',
         'aab' => 'application/x-authorware-bin',
-        'aac' => 'audio/acc',
+        'aac' => 'audio/aac',
         'aam' => 'application/x-authorware-map',
         'aas' => 'application/x-authorware-seg',
         'abw' => 'application/x-abiword',

--- a/src/Generation/FlysystemProvidedMimeTypeProvider.php
+++ b/src/Generation/FlysystemProvidedMimeTypeProvider.php
@@ -156,7 +156,7 @@ class FlysystemProvidedMimeTypeProvider implements MimeTypeProvider
             new MimeTypeForExtension('video/mp4', 'f4v'),
             new MimeTypeForExtension('video/webm', 'webm'),
             new MimeTypeForExtension('audio/x-aac', 'aac'),
-            new MimeTypeForExtension('audio/acc', 'aac'),
+            new MimeTypeForExtension('audio/aac', 'aac'),
             new MimeTypeForExtension('application/vnd.mpegurl', 'm4u'),
             new MimeTypeForExtension('text/plain', 'm3u'),
             new MimeTypeForExtension('application/xspf+xml', 'xspf'),


### PR DESCRIPTION
I've noticed that the mime type given for the `.aac` extension is incorrectly mapped to the non-existent type `audio/acc` instead of `audio/aac`.

This PR adjusts the extension mappings to fix this.