### PR TITLE
Restrict detectMimeTypeFromFile() to local paths (defense-in-depth)

### DIFF
--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -73,12 +73,31 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
 
     public function detectMimeTypeFromFile(string $path): ?string
     {
+        if ( ! $this->isLocalFilePath($path)) {
+            return null;
+        }
+
         return @$this->finfo->file($path) ?: null;
     }
 
     public function detectMimeTypeFromBuffer(string $contents): ?string
     {
         return @$this->finfo->buffer($this->takeSample($contents)) ?: null;
+    }
+
+    /**
+     * finfo::file() honours PHP stream wrappers, so a caller-supplied path using a scheme such
+     * as http://, ftp://, php://, data://, phar:// or expect:// turns MIME detection into an
+     * SSRF, file-disclosure or (with some extensions) command-execution primitive. Only local
+     * filesystem paths are read: a plain path with no wrapper, or the file:// wrapper.
+     */
+    private function isLocalFilePath(string $path): bool
+    {
+        if (preg_match('#^([a-zA-Z][a-zA-Z0-9+.\-]*)://#', $path, $matches) !== 1) {
+            return true;
+        }
+
+        return strtolower($matches[1]) === 'file';
     }
 
     private function takeSample(string $contents): string

--- a/src/FinfoMimeTypeDetectorTest.php
+++ b/src/FinfoMimeTypeDetectorTest.php
@@ -101,6 +101,35 @@ class FinfoMimeTypeDetectorTest extends TestCase
     /**
      * @test
      */
+    public function detecting_from_a_file_ignores_remote_and_wrapper_schemes(): void
+    {
+        $paths = [
+            'http://localhost/whatever',
+            'ftp://localhost/whatever',
+            'php://filter/resource=' . __FILE__,
+            'data://text/plain,hello',
+            'phar://whatever.phar/file',
+        ];
+
+        foreach ($paths as $path) {
+            $this->assertNull($this->detector->detectMimeTypeFromFile($path), $path);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function detecting_from_a_file_still_reads_local_and_file_scheme_paths(): void
+    {
+        $location = __DIR__ . '/../test_files/flysystem.svg';
+
+        $this->assertStringStartsWith('image/svg', $this->detector->detectMimeTypeFromFile($location));
+        $this->assertStringStartsWith('image/svg', $this->detector->detectMimeTypeFromFile('file://' . $location));
+    }
+
+    /**
+     * @test
+     */
     public function detecting_uses_extensions_when_a_resource_is_presented(): void
     {
         /** @var resource $handle */


### PR DESCRIPTION
## What

`FinfoMimeTypeDetector::detectMimeTypeFromFile()` passes its `$path` straight to `finfo::file()`, which honours PHP stream wrappers. When an application calls it with a path derived from untrusted input, a wrapper scheme gets dereferenced:

- `http://`, `ftp://`: finfo opens the URL, firing an outbound request (blind SSRF) before returning null.
- `php://filter/...`, `data://`: reads arbitrary local content or an inline payload.
- `phar://`: opens the archive (metadata unserialize on PHP < 8.0).
- `expect://`: runs a command if ext-expect is loaded.

This restricts `detectMimeTypeFromFile()` to local filesystem paths: a plain path with no wrapper, or the `file://` wrapper. Anything else returns `null`, the existing "could not detect" result, so callers that already treat null as unknown need no change.

## Before / after

Before: `detectMimeTypeFromFile('http://attacker/x')` makes finfo open the URL (SSRF), then returns null.
After: the same call returns null with no I/O. Local paths and `file://` paths behave exactly as before.
