### PR TITLE
avoid test failure because of array order

### DIFF
--- a/src/GeneratedExtensionToMimeTypeMapTest.php
+++ b/src/GeneratedExtensionToMimeTypeMapTest.php
@@ -68,6 +68,8 @@ class GeneratedExtensionToMimeTypeMapTest extends TestCase
         $actual = $map->lookupAllExtensions($mimeType);
 
         // assert
+        sort($expectedExtensions);
+        sort($actual);
         $this->assertEquals($expectedExtensions, $actual);
     }
 


### PR DESCRIPTION
Without this patch

```
PHPUnit 10.5.64 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.6.0alpha1
Configuration: /dev/shm/BUILD/php-league-mime-type-detection-1.17.0-build/mime-type-detection-1.17.0/phpunit.xml.dist

.................F...                                             21 / 21 (100%)

Time: 00:00.016, Memory: 11.00 MB

There was 1 failure:

1) League\MimeTypeDetection\GeneratedExtensionToMimeTypeMapTest::looking_up_extensions with data set #1 ('image/jpeg', ['jpeg', 'jpg', 'jpe', 'jfif'])
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'jpeg'
-    1 => 'jpg'
+    0 => 'jpg'
+    1 => 'jpeg'
     2 => 'jpe'
     3 => 'jfif'
 )

/dev/shm/BUILD/php-league-mime-type-detection-1.17.0-build/mime-type-detection-1.17.0/src/GeneratedExtensionToMimeTypeMapTest.php:71

FAILURES!

```


Notice "main" branch is outdated, changes in 1.17.0 tag are missing.